### PR TITLE
Improve contribution analysis

### DIFF
--- a/analyse-contributions/index.ts
+++ b/analyse-contributions/index.ts
@@ -12,7 +12,7 @@ import { Comment, Issue, PullRequest } from "./src/types";
   }
 
   const github = new GitHubClient(AUTH_TOKEN, new Date(FROM));
-  
+
   // Make sure we can connect to the GitHub API
   await github.authenticate();
 

--- a/analyse-contributions/src/github-client.ts
+++ b/analyse-contributions/src/github-client.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "octokit";
 import { readCollection } from "./github-helper";
-import { Comment, Issue, PullRequest } from "./types";
+import { Comment, Issue, PullRequest, Repository } from "./types";
 
 const RELEVANT_REPOSITORIES = ["sequelize", "cli", "umzug"];
 
@@ -8,6 +8,7 @@ export default class GitHubClient {
   private octokit: Octokit;
   private from: Date;
   private org: string = "sequelize";
+  private repositories: Repository[] = [];
 
   constructor(token: string, from: Date) {
     this.octokit = new Octokit({
@@ -18,6 +19,17 @@ export default class GitHubClient {
 
   async authenticate() {
     const { data } = await this.octokit.rest.users.getAuthenticated();
+    const repositories = await this.readRepositories();
+
+    this.repositories = repositories;
+
+    return data;
+  }
+
+  async readRepositories() {
+    const { data } = await this.octokit.rest.repos.listForOrg({
+      org: this.org,
+    });
 
     return data;
   }
@@ -32,10 +44,10 @@ export default class GitHubClient {
 
   readPullRequests(): Promise<PullRequest[]> {
     return Promise.all(
-      RELEVANT_REPOSITORIES.map((repo: string) =>
+      this.repositories.map((repo: Repository) =>
         readCollection<PullRequest>(this.from, this.octokit.rest.pulls.list, {
           owner: this.org,
-          repo,
+          repo: repo.name,
           state: "closed",
         })
       )
@@ -44,10 +56,10 @@ export default class GitHubClient {
 
   readIssues(): Promise<Issue[]> {
     return Promise.all(
-      RELEVANT_REPOSITORIES.map((repo: string) =>
+      this.repositories.map((repo: Repository) =>
         readCollection<Issue>(this.from, this.octokit.rest.issues.list, {
           owner: this.org,
-          repo,
+          repo: repo.name,
           state: "closed",
         })
       )

--- a/analyse-contributions/src/github-client.ts
+++ b/analyse-contributions/src/github-client.ts
@@ -52,8 +52,8 @@ export default class GitHubClient {
     ).then((results) => results.flat(1));
   }
 
-  readIssues(): Promise<Issue[]> {
-    return Promise.all(
+  async readIssues(): Promise<Issue[]> {
+    const issues = await Promise.all(
       this.repositories.map((repo: Repository) =>
         readCollection<Issue>(this.from, this.octokit.rest.issues.list, {
           owner: this.org,
@@ -62,6 +62,11 @@ export default class GitHubClient {
         })
       )
     ).then((results) => results.flat(1));
+    const uniqueIssues = issues.reduce((acc: any, issue: Issue) => {
+      return { ...acc, [issue.id]: issue };
+    }, {});
+
+    return Object.values(uniqueIssues);
   }
 
   async readPullRequestComments(pullRequest: PullRequest) {

--- a/analyse-contributions/src/github-client.ts
+++ b/analyse-contributions/src/github-client.ts
@@ -2,8 +2,6 @@ import { Octokit } from "octokit";
 import { readCollection } from "./github-helper";
 import { Comment, Issue, PullRequest, Repository } from "./types";
 
-const RELEVANT_REPOSITORIES = ["sequelize", "cli", "umzug"];
-
 export default class GitHubClient {
   private octokit: Octokit;
   private from: Date;

--- a/analyse-contributions/src/types.ts
+++ b/analyse-contributions/src/types.ts
@@ -16,6 +16,7 @@ export type PullRequest = Links &
   };
 
 export type Issue = Timestamps & {
+  id: number;
   user: User;
   number: number;
   title: string;


### PR DESCRIPTION
This PR makes the analysis script respect all sequelize repositories. Furthermore, we only count unique comments per issues/pr. 

Previously each single comment on a ticket would count (which might be fair :) after all it's work). However, it was never meant to be like this and the distributions seems much fairer now. 

Before:

```
Overall stats
-------------
sdepold: 34% (total: 236, pr: 24, issues: 66, comments: 146)
ephys: 29% (total: 202, pr: 78, issues: 0, comments: 124)
WikiRik: 28% (total: 197, pr: 40, issues: 0, comments: 157)
bl0cknumber: 5% (total: 37, pr: 14, issues: 0, comments: 23)
jesse23: 0% (total: 4, pr: 4, issues: 0, comments: 0)
AllAwesome497: 0% (total: 3, pr: 0, issues: 0, comments: 3)
janmeier: 0% (total: 1, pr: 0, issues: 0, comments: 1)
```

After:

```

Overall stats
-------------
ephys: 45% (total: 118, pr: 78, issues: 0, comments: 40)
WikiRik: 27% (total: 71, pr: 40, issues: 0, comments: 31)
sdepold: 18% (total: 47, pr: 24, issues: 3, comments: 20)
bl0cknumber: 6% (total: 16, pr: 14, issues: 0, comments: 2)
jesse23: 1% (total: 4, pr: 4, issues: 0, comments: 0)
AllAwesome497: 1% (total: 3, pr: 0, issues: 0, comments: 3)
janmeier: 0% (total: 1, pr: 0, issues: 0, comments: 1)
```